### PR TITLE
Fix metering-mode enum parsing for CLI

### DIFF
--- a/deezy/enums/__init__.py
+++ b/deezy/enums/__init__.py
@@ -63,7 +63,7 @@ def case_insensitive_enum(enum_class):
     def converter(value):
         v = value.strip()
 
-        #first try name
+        # first try name
         try:
             members = enum_class.__members__
             key = v.upper()
@@ -72,7 +72,7 @@ def case_insensitive_enum(enum_class):
         except Exception:
             pass
 
-        #then try value match (case-insensitive)
+        # then try value match (case-insensitive)
         for member in enum_class:
             if str(member.value).lower() == v.lower():
                 return member


### PR DESCRIPTION
CLI guide said metering mode accepts 1770_1/2/3/leqa, but parser only accepted enum names, so 1770_1/2/3 failed.

fix: case_insensitive_enum now matches on enum values as well.